### PR TITLE
Related issue: Clear sidebar tree navigator with unopened folders #63

### DIFF
--- a/src/js/services/filenavigator.js
+++ b/src/js/services/filenavigator.js
@@ -88,7 +88,7 @@
                     parent.nodes.push({item: item, name: absName, nodes: []});
                 }
                 parent.nodes = parent.nodes.sort(function(a, b) {
-                    return a.name < b.name ? -1 : a.name === b.name ? 0 : 1;
+                    return a.name.toLowerCase() < b.name.toLowerCase() ? -1 : a.name.toLowerCase() === b.name.toLowerCase() ? 0 : 1;
                 });
             };
 


### PR DESCRIPTION
Sort order in sidebar is now the same as in main-table. Added name
comparison in lowercase in method buildTree of the service filenavigator.
Related issue: Clear sidebar tree navigator with unopened folders #63