### PR TITLE
Missing reference to $this->translate

### DIFF
--- a/bridges/php-local/LocalBridge/FileManagerApi.php
+++ b/bridges/php-local/LocalBridge/FileManagerApi.php
@@ -166,6 +166,8 @@ class FileManagerApi
 
     public function getHandler($queries)
     {
+        $t = $this->translate;
+        
         switch ($queries['action']) {
             case 'download':
                 $downloaded = $this->downloadAction($queries['path']);


### PR DESCRIPTION
When generating an error response in the "getHandler" the $t variable was missing. THis is supposed to be a reference to $this->translate.