### PR TITLE
Update README.md, add link to configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ angular.module('FileManagerApp').config(['fileManagerConfigProvider', function (
 </script>
 ```
 
+You can do many things by extending the configuration. Like hide the sidebar or the search button. See [/src/js/providers/config.js](You can see the list of default configurations).
+
 ---------
 
 ### Contribute


### PR DESCRIPTION
Who visiting the repo, don't see the list of configuration.
In this pull-request I added a link in the README.md to the default configration file, so new users can learn what they can do in the amazing component.