### PR TITLE
Contextmenu positioning problem.

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -28,7 +28,7 @@
         menu.hide().css({
             left: e.pageX,
             top: e.pageY
-        }).show();
+        }).appendTo('body').show();
         e.preventDefault();
     });
 

--- a/src/js/services/filenavigator.js
+++ b/src/js/services/filenavigator.js
@@ -21,6 +21,9 @@
             if (code == 404) {
                 this.error = 'Error 404 - Backend bridge is not working, please check the ajax response.';
             }
+            if (code == 200) {
+                this.error = '';
+            }
             if (!this.error && data.result && data.result.error) {
                 this.error = data.result.error;
             }


### PR DESCRIPTION
Fix: If angular-filemanager was embedded in some other parent div (e.g. a Bootstrap modal) with CSS position absolute or relative, then the position of contextmenu would be wrong. Append menu to body solves this problem.
