### PR TITLE
Patch problem of "invalid path" when upload with Tornado

### DIFF
--- a/bridges/python/tornado/filemanager.py
+++ b/bridges/python/tornado/filemanager.py
@@ -274,7 +274,7 @@ class FileManager:
 
     def upload(self, handler):
         try:
-            destination = handler.get_body_argument('destination', default='/')
+            destination = handler.get_body_argument('destination', default='/')[1:]
             for name in handler.request.files:
                 fileinfo = handler.request.files[name][0]
                 filename = fileinfo['filename']


### PR DESCRIPTION
os.path.join() acts weird when destination starts with a slash. For fix it, I suggest to remove it.