### PR TITLE
make bridge-django working on django:2.0.7

### DIFF
--- a/bridges/python/django/filemanager_app/filemanager.py
+++ b/bridges/python/django/filemanager_app/filemanager.py
@@ -287,7 +287,7 @@ class FileManager:
             folders.append(_path)
         tmpdir = tempfile.mkdtemp()
         filename = items['toFilename'][0].replace('.zip', '',1)
-        saved_umask = os.umask(0077)
+        saved_umask = os.umask(77)
         path = os.path.join(tmpdir, filename)
         try:
             compress_zip(path, folders)

--- a/bridges/python/django/filemanager_app/templates/filemanager_app/index.html
+++ b/bridges/python/django/filemanager_app/templates/filemanager_app/index.html
@@ -12,12 +12,12 @@
   <title>angular-filemanager</title>
 
   <!-- third party -->
-    <script src="{% static '../../../../../bower_components/angular/angular.min.js' %}"></script>
-    <script src="{% static '../../../../../bower_components/angular-translate/angular-translate.min.js'%}"></script>
-    <script src="{% static '../../../../../bower_components/ng-file-upload/ng-file-upload.min.js'%}"></script>
-    <script src="{% static '../../../../../bower_components/jquery/dist/jquery.min.js'%}"></script>
-    <script src="{% static '../../../../../bower_components/bootstrap/dist/js/bootstrap.min.js'%}"></script>
-    <link rel="stylesheet" href="{% static '../../../../../bower_components/bootswatch/paper/bootstrap.min.css'%}" />
+    <script src="{% static 'filemanager_app/bower_components/angular/angular.min.js' %}"></script>
+    <script src="{% static 'filemanager_app/bower_components/angular-translate/angular-translate.min.js'%}"></script>
+    <script src="{% static 'filemanager_app/bower_components/ng-file-upload/ng-file-upload.min.js'%}"></script>
+    <script src="{% static 'filemanager_app/bower_components/jquery/dist/jquery.min.js'%}"></script>
+    <script src="{% static 'filemanager_app/bower_components/bootstrap/dist/js/bootstrap.min.js'%}"></script>
+    <link rel="stylesheet" href="{% static 'filemanager_app/bower_components/bootswatch/paper/bootstrap.min.css'%}" />
   <!-- /third party -->
 
   <!-- Uncomment if you need to use raw source code
@@ -39,8 +39,8 @@
   -->
 
   <!-- Comment if you need to use raw source code -->
-    <link href="{% static '../../../../../dist/angular-filemanager.min.css'%}" rel="stylesheet">
-    <script src="{% static '../../../../../dist/angular-filemanager.min.js'%}"></script>
+    <link href="{% static 'filemanager_app/dist/angular-filemanager.min.css'%}" rel="stylesheet">
+    <script src="{% static 'filemanager_app/dist/angular-filemanager.min.js'%}"></script>
   <!-- /Comment if you need to use raw source code -->
 
   <script type="text/javascript">

--- a/bridges/python/django/filemanager_app/urls.py
+++ b/bridges/python/django/filemanager_app/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from django.conf.urls import url
 from django.contrib import admin
-import views as fm
+from . import views as fm
 
 urlpatterns = [
     url(r'^$', fm.index),

--- a/bridges/python/django/filemanager_app/views.py
+++ b/bridges/python/django/filemanager_app/views.py
@@ -4,13 +4,13 @@ import json
 from django.http import HttpResponse
 import shutil
 import os
-from filemanager import FileManager
+from .filemanager import FileManager
 
 fm = FileManager('/home', False)
 
 
 def index(request):
-    return render(request, 'index.html')
+    return render(request, 'filemanager_app/index.html')
 
 
 def list_(request):


### PR DESCRIPTION
Hello, I've fixed some django backend bridge codes like import path or static file path in template/index.html. And index.html moved to template/filemanager_app/index.html following djangoproject website reference.
Not much but now it's working on django 2.0.7